### PR TITLE
version 4.13.1 for antlr-maven-plugin and antlr-runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.9.3</version>
+            <version>4.13.1</version>
         </dependency>
     </dependencies>
 
@@ -120,7 +120,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.9.3</version>
+                <version>4.13.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Set version of antlr-runtime and antlr-maven-plugin to 4.13.1 due to API incompatibilities with jQA-Core 2.2.0-M2.